### PR TITLE
rebranded dev-notes subdomain to wiki

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added mobile touch events using [vue2-touch-events](https://github.com/jerrybendy/vue-touch-events) per PR [#34](https://github.com/iancleary/personal-website/pull/34)
 - Added alt-text and svg immediate loading per PR [#33](https://github.com/iancleary/personal-website/pull/33)
 - Added navbar automatic hidding on scroll down, showing on scroll up, and opaque responsive on mobile per PR [#30](https://github.com/iancleary/personal-website/pull/30)
+- changed URL for [wiki rebrand](https://github.com/iancleary/wiki/pull/4), from dev-notes
 
 ## [1.0.0-alpha] - 2019-09-22
 

--- a/src/pages/Index.vue
+++ b/src/pages/Index.vue
@@ -102,9 +102,9 @@
             <div class="text-lg text-gray-600">
               Check out my more detailed notes at
               <a
-                href="https://dev-notes.iancleary.me/local-computer/"
+                href="https://wiki.iancleary.me/local-computer/"
                 target="_blank"
-              >dev-notes.iancleary.me/local-computer</a>.
+              >wiki.iancleary.me/local-computer</a>.
                Make a pull request and/or use my setup as inspiration!
             </div>
           </li>


### PR DESCRIPTION
Rebranded wiki subdomain per https://github.com/iancleary/wiki/pull/4